### PR TITLE
add "include <cstdint>" to math/lowbits.hpp

### DIFF
--- a/src/libmaus2/math/lowbits.hpp
+++ b/src/libmaus2/math/lowbits.hpp
@@ -22,6 +22,7 @@
 
 #include <libmaus2/types/types.hpp>
 #include <climits>
+#include <cstdint>
 
 namespace libmaus2
 {


### PR DESCRIPTION
Fix "lowbits' is not a member of 'libmaus2::math'; did you mean 'LowBits'" error while running metagraph make install on ubuntu 16.04.
 [Full paste](https://ideone.com/Rc9g3U) 

Similar issues:
https://github.com/facebook/hermes/issues/261 
https://github.com/zeek/zeek/issues/970 
